### PR TITLE
update misleading DSL statement 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "2.10.1"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "2.10.0-SNAPSHOT"
 
 group 'uk.gov.hmcts'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "2.10.0-SNAPSHOT"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "2.10.1"
 
 group 'uk.gov.hmcts'
 

--- a/src/main/java/uk/gov/hmcts/befta/DefaultTestAutomationAdapter.java
+++ b/src/main/java/uk/gov/hmcts/befta/DefaultTestAutomationAdapter.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.befta.data.UserData;
 import uk.gov.hmcts.befta.exception.FunctionalTestException;
 import uk.gov.hmcts.befta.player.BackEndFunctionalTestScenarioContext;
 import uk.gov.hmcts.befta.util.EnvironmentVariableUtils;
+import uk.gov.hmcts.befta.util.ReflectionUtils;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.ServiceAuthTokenGenerator;
 
@@ -157,6 +158,18 @@ public class DefaultTestAutomationAdapter implements TestAutomationAdapter {
     
                 case "actualresponsebody":
                     return scenarioContext.getTestData().getActualResponse().getBody();
+                case "tokenvaluefromaccompanyingtokencall":
+                    try {
+                    String accompanyingTokenCreationDataId = scenarioContext.getTestData().get_guid_()
+                            + "_Token_Creation";
+                        return ReflectionUtils
+                                .deepGetFieldInObject(scenarioContext,
+                                    "scenarioContext.siblingContexts." + accompanyingTokenCreationDataId
+                                            + ".testData.actualResponse.body.token");
+                        
+                } catch (Exception e) {
+                    throw new FunctionalTestException("Failed to get custom value", e);
+                }
             }
             String dateTimeFormat = getDateTimeFormatRequested((String) key);
             if (dateTimeFormat != null)

--- a/src/main/java/uk/gov/hmcts/befta/player/BackEndFunctionalTestScenarioContext.java
+++ b/src/main/java/uk/gov/hmcts/befta/player/BackEndFunctionalTestScenarioContext.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.befta.util.DynamicValueInjector;
 public class BackEndFunctionalTestScenarioContext {
 
     private static final String[] TEST_DATA_RESOURCE_PACKAGES = { "features" };
-    private static final HttpTestDataSource DATA_SOURCE = new JsonStoreHttpTestDataSource(TEST_DATA_RESOURCE_PACKAGES);
+    static final HttpTestDataSource DATA_SOURCE = new JsonStoreHttpTestDataSource(TEST_DATA_RESOURCE_PACKAGES);
 
     @Getter
     private Scenario scenario;

--- a/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
+++ b/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
@@ -77,7 +77,7 @@ public class DefaultBackEndFunctionalTestScenarioPlayer implements BackEndFuncti
     @Override
     @Given("a case that has just been created as in [{}]")
     public void createCaseWithTheDataProvidedInATestDataObject(String caseCreationDataId) throws IOException {
-        String accompanyingTokenCreationDataId = "Token_Creation_For_" + caseCreationDataId;
+        String accompanyingTokenCreationDataId = caseCreationDataId + "_Token_Creation";
         HttpTestData tokenCreationData = BackEndFunctionalTestScenarioContext.DATA_SOURCE
                 .getDataForTestCall(accompanyingTokenCreationDataId);
         if (tokenCreationData == null) {

--- a/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
+++ b/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
@@ -75,7 +75,7 @@ public class DefaultBackEndFunctionalTestScenarioPlayer implements BackEndFuncti
     }
 
     @Override
-    @Given("a case that has just been created as in [{}]")
+    @Given("a case that has just been created as in Standard_Token_Creation_Data_For_Case_Creation and another case has also been created as in [{}]")
     public void createCaseWithTheDataProvidedInATestDataObject(String caseCreationDataId) throws IOException {
 
         performAndVerifyTheExpectedResponseForAnApiCall("to create a token for case creation",

--- a/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
+++ b/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
@@ -75,7 +75,7 @@ public class DefaultBackEndFunctionalTestScenarioPlayer implements BackEndFuncti
     }
 
     @Override
-    @Given("a case that has just been created as in Standard_Token_Creation_Data_For_Case_Creation and another case has also been created as in [{}]")
+    @Given("a case that has just been created for AAT_AUTH_15 casetype in the AUTOTEST1 jurisdiction as in [{}]")
     public void createCaseWithTheDataProvidedInATestDataObject(String caseCreationDataId) throws IOException {
 
         performAndVerifyTheExpectedResponseForAnApiCall("to create a token for case creation",

--- a/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
+++ b/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
@@ -75,11 +75,16 @@ public class DefaultBackEndFunctionalTestScenarioPlayer implements BackEndFuncti
     }
 
     @Override
-    @Given("a case that has just been created for AAT_AUTH_15 casetype in the AUTOTEST1 jurisdiction as in [{}]")
+    @Given("a case that has just been created as in [{}]")
     public void createCaseWithTheDataProvidedInATestDataObject(String caseCreationDataId) throws IOException {
-
+        String accompanyingTokenCreationDataId = "Token_Creation_For_" + caseCreationDataId;
+        HttpTestData tokenCreationData = BackEndFunctionalTestScenarioContext.DATA_SOURCE
+                .getDataForTestCall(accompanyingTokenCreationDataId);
+        if (tokenCreationData == null) {
+            accompanyingTokenCreationDataId = "Standard_Token_Creation_Data_For_Case_Creation";
+        }
         performAndVerifyTheExpectedResponseForAnApiCall("to create a token for case creation",
-                "Standard_Token_Creation_Data_For_Case_Creation");
+                accompanyingTokenCreationDataId);
         performAndVerifyTheExpectedResponseForAnApiCall("to create a full case", caseCreationDataId);
     }
 


### PR DESCRIPTION
### Jira Ticket ###
https://tools.hmcts.net/jira/browse/RDM-8566

### Change description ###
We have a DSL statement currently creates a completely different case type from what ever the case type the user specifies, only after this will the specified case type actually be created as per  specified using the DSL - this is misleading to the end user. The implementation of the DSL element has been improved to allow for implied token creation data id, so that the standard token creation will be used only when no accompanying token creation data is provided.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
