### PR TITLE
Am 891 oidc scope fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/befta/DefaultTestAutomationAdapter.java
+++ b/src/main/java/uk/gov/hmcts/befta/DefaultTestAutomationAdapter.java
@@ -132,7 +132,7 @@ public class DefaultTestAutomationAdapter implements TestAutomationAdapter {
     private String getIdamOidcToken(String username, String password, UserTokenProviderConfig tokenProviderConfig) {
 
         AuthApi.TokenExchangeResponse generateOIDCToken = idamApi.generateOIDCToken(tokenProviderConfig.getClientId(),
-                tokenProviderConfig.getClientSecret(), PASSWORD, SCOPE, username, password);
+                tokenProviderConfig.getClientSecret(), PASSWORD, tokenProviderConfig.getScopeVariables(), username, password);
 
         return generateOIDCToken.getAccessToken();
     }

--- a/src/main/java/uk/gov/hmcts/befta/DefaultTestAutomationAdapter.java
+++ b/src/main/java/uk/gov/hmcts/befta/DefaultTestAutomationAdapter.java
@@ -28,7 +28,6 @@ public class DefaultTestAutomationAdapter implements TestAutomationAdapter {
     private static final String CODE = "code";
     private static final String BASIC = "Basic ";
     private static final String PASSWORD = "password";
-    private static final String SCOPE = "openid%20profile%20roles%20authorities%20email";
 
     private final AuthApi idamApi;
 

--- a/src/main/java/uk/gov/hmcts/befta/auth/UserTokenProviderConfig.java
+++ b/src/main/java/uk/gov/hmcts/befta/auth/UserTokenProviderConfig.java
@@ -14,12 +14,14 @@ public class UserTokenProviderConfig {
     private final String clientSecret;
     private final String redirectUri;
     private String accessTokenType;
+    private String scopeVariables;
 
     private UserTokenProviderConfig() {
         clientId = EnvironmentVariableUtils.getRequiredVariable("OAUTH2_CLIENT_ID");
         clientSecret = EnvironmentVariableUtils.getRequiredVariable("OAUTH2_CLIENT_SECRET");
         redirectUri = EnvironmentVariableUtils.getRequiredVariable("OAUTH2_REDIRECT_URI");
         accessTokenType = EnvironmentVariableUtils.getOptionalVariable("OAUTH2_ACCESS_TOKEN_TYPE");
+        scopeVariables = EnvironmentVariableUtils.getOptionalVariable("OAUTH2_SCOPE_VARIABLES");
         if (accessTokenType == null) {
             accessTokenType = OAUTH2;
         }
@@ -32,7 +34,9 @@ public class UserTokenProviderConfig {
         redirectUri = EnvironmentVariableUtils
                 .getRequiredVariable("BEFTA_OAUTH2_REDIRECT_URI_OF_" + tokenProviderClientId.toUpperCase());
         accessTokenType = EnvironmentVariableUtils
-                .getRequiredVariable("BEFTA_OAUTH2_ACCESS_TOKEN_TYPE_OF_" + tokenProviderClientId.toUpperCase());
+                .getOptionalVariable("BEFTA_OAUTH2_ACCESS_TOKEN_TYPE_OF_" + tokenProviderClientId.toUpperCase());
+        scopeVariables = EnvironmentVariableUtils
+                .getOptionalVariable("BEFTA_OAUTH2_SCOPE_VARIABLES_OF_" + tokenProviderClientId.toUpperCase());
     }
 
     public static UserTokenProviderConfig of(String tokenProviderClientId) {


### PR DESCRIPTION
### Change description ###
Flexibility to consume scope variables provided by BEFTA consumer client. This is required in OIDC token generation.
Earlier it was hardcoded but now it is being picked from the optional environment variable.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
