### PR TITLE
RDM-9118 Dynamic Value and Reflection Util updates

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build
       run: ./gradlew check
     - name: Archive test reports
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: test-reports

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,6 +22,11 @@ jobs:
         java-version: 1.8
     - name: Build
       run: ./gradlew check
+    - name: Archive test report
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-report
+        path: build/reports/tests/test
     - name: Release
       env:
         BINTRAY_USER: jenkins-reform-hmcts

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,11 +22,12 @@ jobs:
         java-version: 1.8
     - name: Build
       run: ./gradlew check
-    - name: Archive test report
+    - name: Archive test reports
+      if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: test-report
-        path: build/reports/tests/test
+        name: test-reports
+        path: build/reports/tests/
     - name: Release
       env:
         BINTRAY_USER: jenkins-reform-hmcts

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "5.0.1-SNAPSHOT"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "5.1.0"
 
 group 'uk.gov.hmcts'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "5.0.0"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "5.0.1-SNAPSHOT"
 
 group 'uk.gov.hmcts'
 

--- a/src/main/java/uk/gov/hmcts/befta/util/DynamicValueInjector.java
+++ b/src/main/java/uk/gov/hmcts/befta/util/DynamicValueInjector.java
@@ -116,15 +116,9 @@ public class DynamicValueInjector {
 
                 // special case when complete input is a dynamic formula
                 // : so check if it returned a complex object to return
-                if ((pos == 0 && jumpTo >= input.length())
-                        && (partValue == null
-                        || partValue instanceof Map<?, ?>
-                        || partValue instanceof Object[]
-                        || partValue instanceof Iterable)
-                ) {
+                if (pos == 0 && jumpTo >= input.length()) {
                     return partValue;
                 }
-
             } else if (anEnvVarIsStartingAt(input, pos)) {
                 int closingAt = input.indexOf("}}", pos + 2);
                 if (closingAt < 0) {

--- a/src/main/java/uk/gov/hmcts/befta/util/DynamicValueInjector.java
+++ b/src/main/java/uk/gov/hmcts/befta/util/DynamicValueInjector.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.befta.util;
 
-import com.google.common.collect.FluentIterable;
-
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import uk.gov.hmcts.befta.TestAutomationAdapter;
 import uk.gov.hmcts.befta.data.HttpTestData;
@@ -111,6 +113,18 @@ public class DynamicValueInjector {
                 String formulaPart = input.substring(pos, closingAt + 1);
                 partValue = calculateFormulaFromContext(scenarioContext, formulaPart);
                 jumpTo = closingAt + 1;
+
+                // special case when complete input is a dynamic formula
+                // : so check if it returned a complex object to return
+                if ((pos == 0 && jumpTo >= input.length())
+                        && (partValue == null
+                        || partValue instanceof Map<?, ?>
+                        || partValue instanceof Object[]
+                        || partValue instanceof Iterable)
+                ) {
+                    return partValue;
+                }
+
             } else if (anEnvVarIsStartingAt(input, pos)) {
                 int closingAt = input.indexOf("}}", pos + 2);
                 if (closingAt < 0) {
@@ -157,30 +171,41 @@ public class DynamicValueInjector {
         map.forEach((key, value) -> {
             if (value instanceof String) {
                 map.put(key, processDynamicValuesIn((String) value));
-            } else if (isArray(value)) {
-                injectDynamicValuesInto(path + "." + key, (Object[]) value);
             } else if (value instanceof Map<?, ?>) {
                 injectDynamicValuesInto(path + "." + key, (Map<String, Object>) value);
+            } else if (isArray(value)) {
+                ArrayList<Object> values = new ArrayList<>(Arrays.asList((Object[]) value));
+                injectDynamicValuesInto(path + "." + key, values);
+                map.put(key, values);
             } else if (value instanceof Iterable) {
-                injectDynamicValuesInto(path + "." + key,
-                        FluentIterable.from((Iterable<Object>) value).toArray(Object.class));
+                ArrayList<Object> values = StreamSupport.stream(((Iterable<Object>) value).spliterator(), false)
+                        .collect(Collectors.toCollection(ArrayList::new));
+                injectDynamicValuesInto(path + "." + key, values);
+                map.put(key, values);
             }
         });
-
     }
 
     @SuppressWarnings("unchecked")
-    private void injectDynamicValuesInto(String path, Object[] objects) {
+    private void injectDynamicValuesInto(String path, List<Object> objects) {
         if (objects == null) {
             return;
         }
-        for (int i = 0; i < objects.length; i++) {
-            if (objects[i] instanceof String) {
-                objects[i] = processDynamicValuesIn((String) objects[i]);
-            } else if (objects[i] instanceof Map<?, ?>) {
-                injectDynamicValuesInto(path + "[" + i + "]", (Map<String, Object>) objects[i]);
-            } else if (isArray(objects[i])) {
-                injectDynamicValuesInto(path + "[" + i + "]", (Object[]) objects[i]);
+        for (int i = 0; i < objects.size(); i++) {
+            Object value = objects.get(i);
+            if (value instanceof String) {
+                objects.set(i, processDynamicValuesIn((String) value));
+            } else if (value instanceof Map<?, ?>) {
+                injectDynamicValuesInto(path + "[" + i + "]", (Map<String, Object>) value);
+            } else if (isArray(value)) {
+                ArrayList<Object> values = new ArrayList<>(Arrays.asList((Object[]) value));
+                injectDynamicValuesInto(path + "[" + i + "]", values);
+                objects.set(i, values);
+            } else if (value instanceof Iterable) {
+                ArrayList<Object> values = StreamSupport.stream(((Iterable<Object>) value).spliterator(), false)
+                        .collect(Collectors.toCollection(ArrayList::new));
+                injectDynamicValuesInto(path + "[" + i + "]", values);
+                objects.set(i, values);
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/befta/util/DynamicValueInjector.java
+++ b/src/main/java/uk/gov/hmcts/befta/util/DynamicValueInjector.java
@@ -116,9 +116,15 @@ public class DynamicValueInjector {
 
                 // special case when complete input is a dynamic formula
                 // : so check if it returned a complex object to return
-                if (pos == 0 && jumpTo >= input.length()) {
+                if ((pos == 0 && jumpTo >= input.length())
+                        && (partValue == null
+                        || partValue instanceof Map<?, ?>
+                        || partValue instanceof Object[]
+                        || partValue instanceof Iterable)
+                ) {
                     return partValue;
                 }
+
             } else if (anEnvVarIsStartingAt(input, pos)) {
                 int closingAt = input.indexOf("}}", pos + 2);
                 if (closingAt < 0) {

--- a/src/main/java/uk/gov/hmcts/befta/util/ReflectionUtils.java
+++ b/src/main/java/uk/gov/hmcts/befta/util/ReflectionUtils.java
@@ -1,21 +1,31 @@
 package uk.gov.hmcts.befta.util;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ReflectionUtils {
 
     public static Object deepGetFieldInObject(Object object, String fieldPath) throws Exception {
-        if (object == null)
+        if (object == null) {
             return null;
-        if (fieldPath == null || fieldPath.length() == 0)
+        }
+        if (fieldPath == null || fieldPath.length() == 0) {
             throw new IllegalArgumentException("Field path must be non-empty String.");
-        String[] fields = fieldPath.split("\\.");
-        Object fieldValue = retrieveFieldInObject(object, fields[0]);
-        for (int i = 1; i < fields.length; i++) {
-            fieldValue = retrieveFieldInObject(fieldValue, fields[i]);
+        }
+        final String regex = "(?<!\\\\)(?:\\\\\\\\)*\\."; // i.e. look for '.' but not the escaped version '\.'
+        String[] rawFields = fieldPath.split(regex);
+        // unescape fields
+        List<String> fields = Arrays.stream(rawFields)
+                .map(field -> field.replace("\\.", "."))
+                .collect(Collectors.toList());
+
+        Object fieldValue = retrieveFieldInObject(object, fields.get(0));
+        for (int i = 1; i < fields.size(); i++) {
+            fieldValue = retrieveFieldInObject(fieldValue, fields.get(i));
         }
         return fieldValue;
     }

--- a/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
+++ b/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
@@ -11,14 +11,22 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import uk.gov.hmcts.befta.BeftaMain;
 import uk.gov.hmcts.befta.DefaultTestAutomationAdapter;
+import uk.gov.hmcts.befta.TestAutomationConfig;
 import uk.gov.hmcts.befta.data.HttpTestData;
 import uk.gov.hmcts.befta.data.HttpTestDataSource;
 import uk.gov.hmcts.befta.data.JsonStoreHttpTestDataSource;
 import uk.gov.hmcts.befta.player.BackEndFunctionalTestScenarioContext;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(EnvironmentVariableUtils.class)
+@PrepareForTest({EnvironmentVariableUtils.class, BeftaMain.class})
 public class DynamicValueInjectorTest {
 
     private static final String[] TEST_DATA_RESOURCE_PACKAGES = { "framework-test-data" };
@@ -31,7 +39,11 @@ public class DynamicValueInjectorTest {
     private DefaultTestAutomationAdapter taAdapter;
 
     @Before
-    public void prepareScenarioConext() {
+    public void prepareScenarioContext() {
+        PowerMockito.mockStatic(BeftaMain.class);
+        Mockito.when(BeftaMain.getAdapter()).thenReturn(taAdapter);
+        Mockito.when(BeftaMain.getConfig()).thenReturn(TestAutomationConfig.INSTANCE);
+
         scenarioContext = new BackEndFunctionalTestScenarioContextForTest();
 
         scenarioContext.initializeTestDataFor("Simple-Test-Data-With-All-Possible-Dynamic-Values");
@@ -106,7 +118,7 @@ public class DynamicValueInjectorTest {
         Assert.assertEquals("http://idamuser.hmcts.bla.bla/documents/binary",
                 testData.getRequest().getBody().get("event_token"));
 
-        Assert.assertEquals(null, testData.getRequest().getBody().get("nullValueField"));
+        Assert.assertNull(testData.getRequest().getBody().get("nullValueField"));
         Assert.assertEquals(Strings.EMPTY, testData.getExpectedResponse().getBody().get("emptyString"));
         Assert.assertEquals(4.6, testData.getExpectedResponse().getBody().get("onlyStaticNumber"));
         Assert.assertEquals("string without any dynamic part",
@@ -135,11 +147,103 @@ public class DynamicValueInjectorTest {
                 testData.getExpectedResponse().getBody().get("complicatedNestedValue_2"));
     }
 
-    class BackEndFunctionalTestScenarioContextForTest extends BackEndFunctionalTestScenarioContext {
+    @Test
+    public void shouldInjectCustomValuesWithReturnNull() {
+        testAndVerifyInjectionOfCustomValues(null);
+    }
+
+    @Test
+    public void shouldInjectCustomValuesWithReturnTypeString() {
+        String expectedResponse = "EXPECTED_RESPONSE";
+        testAndVerifyInjectionOfCustomValues(expectedResponse);
+    }
+
+    @Test
+    public void shouldInjectCustomValuesWithReturnTypeInteger() {
+        int expectedResponse = 1234;
+        testAndVerifyInjectionOfCustomValues(expectedResponse);
+    }
+
+    @Test
+    public void shouldInjectCustomValuesWithReturnTypeArray() {
+        Object[] expectedResponse = new Object[]{"one", "two", "three"};
+        testAndVerifyInjectionOfCustomValues(expectedResponse);
+    }
+
+    @Test
+    public void shouldInjectCustomValuesWithReturnTypeList() {
+        List<Object> expectedResponse = Arrays.asList("one", "two");
+        testAndVerifyInjectionOfCustomValues(expectedResponse);
+    }
+
+    @Test
+    public void shouldInjectCustomValuesWithReturnTypeMap() {
+        Map<String, Object> expectedResponse = Collections.singletonMap("key", "value");
+        testAndVerifyInjectionOfCustomValues(expectedResponse);
+    }
+
+    private void testAndVerifyInjectionOfCustomValues(Object expectedResponse) {
+        // ARRANGE
+        scenarioContext = new BackEndFunctionalTestScenarioContextForTest();
+        scenarioContext.initializeTestDataFor("Custom-Value-Test-Data");
+        HttpTestData testData = scenarioContext.getTestData();
+
+        Mockito.when(taAdapter.calculateCustomValue(scenarioContext, "test-custom-value-key")).thenReturn(expectedResponse);
+        Mockito.when(taAdapter.calculateCustomValue(scenarioContext, "test-custom-value-string")).thenReturn("INLINE");
+
+        DynamicValueInjector underTest = new DynamicValueInjector(taAdapter, testData, scenarioContext);
+
+        // verify custom-value TD file looks OK prior to execution of test
+        assertCustomValuesTestData(testData, "${[scenarioContext][customValues][test-custom-value-key]}");
+
+        // ACT
+        underTest.injectDataFromContextBeforeApiCall();
+
+        // ASSERT
+        assertCustomValuesTestData(testData, expectedResponse);
+        Assert.assertEquals("BEFORE-INLINE-AFTER", testData.getRequest().getBody().get("inline-value"));
+    }
+
+    private void assertCustomValuesTestData(HttpTestData testData, Object expectedResponse) {
+        // check string test data
+        Assert.assertNull(testData.getRequest().getBody().get("null-check"));
+
+        // check string test data
+        Assert.assertEquals(expectedResponse,
+                testData.getRequest().getBody().get("test-custom-value"));
+
+        // check map test data
+        // : map > null
+        Assert.assertNull(((Map<?,?>)testData.getRequest().getBody().get("map")).get("null-check"));
+        // : map > string
+        Assert.assertEquals(expectedResponse,
+                ((Map<?,?>)testData.getRequest().getBody().get("map")).get("test-custom-value"));
+        // : map > map
+        Assert.assertEquals(expectedResponse,
+                ((Map<?,?>)((Map<?,?>)testData.getRequest().getBody().get("map")).get("map")).get("test-custom-value"));
+        // : map > array
+        Assert.assertEquals(expectedResponse,
+                ((ArrayList<?>)((Map<?,?>)testData.getRequest().getBody().get("map")).get("array")).get(0));
+
+        // check array test data
+        // : array > null
+        Assert.assertNull(((ArrayList<?>)testData.getRequest().getBody().get("array")).get(0));
+        // : array > string
+        Assert.assertEquals(expectedResponse,
+                ((ArrayList<?>)testData.getRequest().getBody().get("array")).get(1));
+        // : array > map
+        Assert.assertEquals(expectedResponse,
+                ((Map<?,?>)((ArrayList<?>)testData.getRequest().getBody().get("array")).get(2)).get("test-custom-value"));
+        // : array > array
+        Assert.assertEquals(expectedResponse,
+                ((ArrayList<?>)((ArrayList<?>)testData.getRequest().getBody().get("array")).get(3)).get(0));
+    }
+
+    static class BackEndFunctionalTestScenarioContextForTest extends BackEndFunctionalTestScenarioContext {
 
         @Override
         public void initializeTestDataFor(String testDataId) {
-            testData = TEST_DATA_RESOURCE.getDataForTestCall(testDataId);
+            testData = new HttpTestData(TEST_DATA_RESOURCE.getDataForTestCall(testDataId));
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
+++ b/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
@@ -239,7 +239,7 @@ public class DynamicValueInjectorTest {
                 ((ArrayList<?>)((ArrayList<?>)testData.getRequest().getBody().get("array")).get(3)).get(0));
     }
 
-    static class BackEndFunctionalTestScenarioContextForTest extends BackEndFunctionalTestScenarioContext {
+    class BackEndFunctionalTestScenarioContextForTest extends BackEndFunctionalTestScenarioContext {
 
         @Override
         public void initializeTestDataFor(String testDataId) {

--- a/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
+++ b/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
@@ -11,9 +11,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import uk.gov.hmcts.befta.BeftaMain;
 import uk.gov.hmcts.befta.DefaultTestAutomationAdapter;
-import uk.gov.hmcts.befta.TestAutomationConfig;
 import uk.gov.hmcts.befta.data.HttpTestData;
 import uk.gov.hmcts.befta.data.HttpTestDataSource;
 import uk.gov.hmcts.befta.data.JsonStoreHttpTestDataSource;
@@ -26,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({EnvironmentVariableUtils.class, BeftaMain.class})
+@PrepareForTest(EnvironmentVariableUtils.class)
 public class DynamicValueInjectorTest {
 
     private static final String[] TEST_DATA_RESOURCE_PACKAGES = { "framework-test-data" };
@@ -40,10 +38,6 @@ public class DynamicValueInjectorTest {
 
     @Before
     public void prepareScenarioContext() {
-        PowerMockito.mockStatic(BeftaMain.class);
-        Mockito.when(BeftaMain.getAdapter()).thenReturn(taAdapter);
-        Mockito.when(BeftaMain.getConfig()).thenReturn(TestAutomationConfig.INSTANCE);
-
         scenarioContext = new BackEndFunctionalTestScenarioContextForTest();
 
         scenarioContext.initializeTestDataFor("Simple-Test-Data-With-All-Possible-Dynamic-Values");
@@ -244,6 +238,11 @@ public class DynamicValueInjectorTest {
         @Override
         public void initializeTestDataFor(String testDataId) {
             testData = new HttpTestData(TEST_DATA_RESOURCE.getDataForTestCall(testDataId));
+        }
+
+        @Override
+        protected Object calculateCustomValue(Object key) {
+            return taAdapter.calculateCustomValue(this, key);
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
+++ b/src/test/java/uk/gov/hmcts/befta/util/DynamicValueInjectorTest.java
@@ -38,17 +38,6 @@ public class DynamicValueInjectorTest {
 
     @Before
     public void prepareScenarioContext() {
-        scenarioContext = new BackEndFunctionalTestScenarioContextForTest();
-
-        scenarioContext.initializeTestDataFor("Simple-Test-Data-With-All-Possible-Dynamic-Values");
-        
-        BackEndFunctionalTestScenarioContext subcontext = new BackEndFunctionalTestScenarioContextForTest();
-        subcontext.initializeTestDataFor("Token_Creation_Call");
-        subcontext.getTestData().setActualResponse(subcontext.getTestData().getExpectedResponse());
-
-        scenarioContext.setTheInvokingUser(scenarioContext.getTestData().getInvokingUser());
-        scenarioContext.addChildContext(subcontext);
-
         PowerMockito.mockStatic(EnvironmentVariableUtils.class);
 
         Mockito.when(EnvironmentVariableUtils.getRequiredVariable("S2S_URL")).thenReturn("http://s2s.hmcts.bla.bla");
@@ -60,6 +49,16 @@ public class DynamicValueInjectorTest {
         Mockito.when(EnvironmentVariableUtils.getRequiredVariable("CCD_CASEWORKER_AUTOTEST_PASSWORD"))
                 .thenReturn("PassQ@rT");
 
+        scenarioContext = new BackEndFunctionalTestScenarioContextForTest();
+
+        scenarioContext.initializeTestDataFor("Simple-Test-Data-With-All-Possible-Dynamic-Values");
+        
+        BackEndFunctionalTestScenarioContext subcontext = new BackEndFunctionalTestScenarioContextForTest();
+        subcontext.initializeTestDataFor("Token_Creation_Call");
+        subcontext.getTestData().setActualResponse(subcontext.getTestData().getExpectedResponse());
+
+        scenarioContext.setTheInvokingUser(scenarioContext.getTestData().getInvokingUser());
+        scenarioContext.addChildContext(subcontext);
     }
     
     @Test

--- a/src/test/java/uk/gov/hmcts/befta/util/ReflectionUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/befta/util/ReflectionUtilsTest.java
@@ -14,11 +14,13 @@ import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import uk.gov.hmcts.befta.data.HttpTestData;
+import uk.gov.hmcts.befta.data.RequestData;
 import uk.gov.hmcts.befta.data.ResponseData;
 import uk.gov.hmcts.befta.data.UserData;
 
@@ -37,6 +39,19 @@ public class ReflectionUtilsTest {
         final Object result = ReflectionUtils.deepGetFieldInObject(testData, "invokingUser.username");
 
         assertEquals("USERNAME", result);
+    }
+
+    @Test
+    public void shouldDeepGetFieldInObject_withEscapedCharacters() throws Exception {
+        HttpTestData testData = new HttpTestData();
+        Map<String, Object> body = Collections.singletonMap("TEST.KEY", "EXPECTED_RESULT");
+        RequestData request = new RequestData();
+        request.setBody(body);
+        testData.setRequest(request);
+
+        final Object result = ReflectionUtils.deepGetFieldInObject(testData, "request.body.TEST\\.KEY");
+
+        assertEquals("EXPECTED_RESULT", result);
     }
 
     @Test

--- a/src/test/resources/framework-test-data/field-injector-test-data/Custom-Value-Test-Data.td.json
+++ b/src/test/resources/framework-test-data/field-injector-test-data/Custom-Value-Test-Data.td.json
@@ -1,0 +1,27 @@
+{
+	"_guid_": "Custom-Value-Test-Data",
+	"title": "Custom Value Test Data",
+	"request": {
+		"body": {
+			"inline-value": "BEFORE-${[scenarioContext][customValues][test-custom-value-string]}-AFTER",
+			"null-check": null,
+			"test-custom-value": "${[scenarioContext][customValues][test-custom-value-key]}",
+			"map": {
+				"null-check": null,
+				"test-custom-value": "${[scenarioContext][customValues][test-custom-value-key]}",
+				"map": { "test-custom-value": "${[scenarioContext][customValues][test-custom-value-key]}" },
+				"array": [
+					"${[scenarioContext][customValues][test-custom-value-key]}"
+				]
+			},
+			"array": [
+				null,
+				"${[scenarioContext][customValues][test-custom-value-key]}",
+				{ "test-custom-value": "${[scenarioContext][customValues][test-custom-value-key]}" },
+				[
+					"${[scenarioContext][customValues][test-custom-value-key]}"
+				]
+			]
+		}
+	}
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

  [RDM-9118](https://tools.hmcts.net/jira/browse/RDM-9118) _"Increment Assigned User Count FTA organisation adjustment"_
  [RDM-8842](https://tools.hmcts.net/jira/browse/RDM-8842) _"Increment Assigned User Count of Cases when Assigned to Users"_

### Change description ###

Framework changes for RDM-9118 FTA organisation adjustment for RDM-8842:
* allow formulas to return more complex items: e.g. map, array...,
* ReflectionUtils.deepGetFieldInObject now supports keys containing `.`,
* adjust dynamic value injection processing of arrays & lists.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
