### PR TITLE
windows fix for path splitter

### DIFF
--- a/src/main/java/uk/gov/hmcts/befta/dse/ccd/definition/converter/JsonTransformer.java
+++ b/src/main/java/uk/gov/hmcts/befta/dse/ccd/definition/converter/JsonTransformer.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import uk.gov.hmcts.befta.dse.ccd.CcdEnvironment;
@@ -66,7 +67,7 @@ public class JsonTransformer {
 
     private String getFolderName(String path){
         String delimiter = File.separator;
-        String[] dirStructure = path.split(delimiter);
+        String[] dirStructure = path.split(Pattern.quote(delimiter));
         return  dirStructure[dirStructure.length-1];
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

File.separator doesn't work properly on Windows system, while it parses files paths by using String.split() function. The main cause here is **split()** processes regex as default and **File.separator** brings "\" which is a special character.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
