### PR TITLE
HMAN-368 ccd-next-hearing-date-updater admin role

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "8.7.6-HMAN-368"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "8.7.6"
 
 group 'com.github.hmcts'
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "8.8.0-SNAPSHOT"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "8.7.6-HMAN-368"
 
 group 'com.github.hmcts'
 
@@ -139,8 +139,9 @@ dependencies {
 
     implementation group: 'io.rest-assured', name: 'rest-assured', version: '4.4.0'
 
-    implementation group: 'io.cucumber', name: 'cucumber-java', version: '5.7.0'
-    implementation group: 'io.cucumber', name: 'cucumber-junit', version: '5.7.0'
+    // NB: these libraries will often be used by the custom BeftaRunner and BeftaAdapter classes in each repo using BEFTA
+    api group: 'io.cucumber', name: 'cucumber-java', version: '5.7.0'
+    api group: 'io.cucumber', name: 'cucumber-junit', version: '5.7.0'
 
     implementation group: 'org.projectlombok', name: 'lombok', version: '1.18.4'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.4'

--- a/src/main/java/uk/gov/hmcts/befta/dse/ccd/DataLoaderToDefinitionStore.java
+++ b/src/main/java/uk/gov/hmcts/befta/dse/ccd/DataLoaderToDefinitionStore.java
@@ -78,7 +78,8 @@ public class DataLoaderToDefinitionStore extends DefaultBeftaTestDataLoader {
         new CcdRoleConfig("caseworker-befta_master-junior", "PUBLIC"),
         new CcdRoleConfig("caseworker-befta_master-manager", "PUBLIC"),
         new CcdRoleConfig("caseworker-caa", "PUBLIC"),
-        new CcdRoleConfig("caseworker-approver", "PUBLIC")
+        new CcdRoleConfig("caseworker-approver", "PUBLIC"),
+        new CcdRoleConfig("next-hearing-date-admin", "PUBLIC")
     };
 
     private TestAutomationAdapter adapter;


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-368](https://tools.hmcts.net/jira/browse/HMAN-368) _"Ccd Def store definition changes"_

### Change description ###

Add admin role for **ccd-next-hearing-date-updater** system account which is require for new test-definitions in: hmcts/ccd-test-definitions#53.

> NB: BEFTA FW & Def file FTA+ES test PRs are:
> * hmcts/ccd-data-store-api#2086
> * hmcts/ccd-definition-store-api#1279
> * hmcts/ccd-user-profile-api#497

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
