### PR TITLE
GA-2_4 To fix actualResponse.body contains a bad value: actualResponse.body.…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "8.8.0"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "8.8.1"
 
 group 'com.github.hmcts'
 

--- a/src/main/java/uk/gov/hmcts/befta/util/MapVerifier.java
+++ b/src/main/java/uk/gov/hmcts/befta/util/MapVerifier.java
@@ -256,19 +256,22 @@ public class MapVerifier {
 
         switch (verificationConfig.getOperator()) {
         case EQUIVALENT:
-            if (actualCount != expectedCount) {
+            if (actualCount != expectedCount
+                    && expectedCollection.size() != actualCollection.size()) {
                 badValueMessages.add(fieldPrefix + " has unexpected number of elements. Expected: "
                         + expectedCollection.size() + ", but actual: " + actualCollection.size() + ".");
             }
             break;
         case SUBSET:
-            if (actualCount > expectedCount) {
+            if (actualCount > expectedCount
+                    && expectedCollection.size() != actualCollection.size()) {
                 badValueMessages.add(fieldPrefix + " has unexpected number of elements. Expected <= "
                         + expectedCollection.size() + ", but actual: " + actualCollection.size() + ".");
             }
             break;
         case SUPERSET:
-            if (actualCount < expectedCount) {
+            if (actualCount < expectedCount
+                    && expectedCollection.size() != actualCollection.size()) {
                 badValueMessages.add(fieldPrefix + " has unexpected number of elements. Expected >= "
                         + expectedCollection.size() + ", but actual: " + actualCollection.size() + ".");
             }


### PR DESCRIPTION
…case_fields has unexpected number of elements. Expected: 38, but actual: 38. in https://build.hmcts.net/job/HMCTS_a_to_c/job/ccd-definition-store-api/job/PR-1426/17/

### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
