### PR TITLE
Escape asterisks in README text

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ This default behavior is configured using the following environment variables:
 * **BEFTA_RETRY_RETRYABLE_EXCEPTIONS:** A comma-separated list of Java exceptions that are considered retryable (default: java.net.SocketException, 
 javax.net.ssl.SSLException, java.net.ConnectException).
 * **BEFTA_RETRY_NON_RETRYABLE_HTTP_METHODS:** A comma-separated list of HTTP methods that should not be retried 
-(default: *). Use "*" to specify that no methods should be retried.
+(default: \*). Use "\*" to specify that no methods should be retried.
 * **BEFTA_RETRY_ENABLE_LISTENER:** A boolean flag indicating whether the Retry Policy listener should be enabled (default: true).
 
 #### Sample Configuration:


### PR DESCRIPTION
### Change description

Escaped asterisks in text describing the BEFTA_RETRY_NON_RETRYABLE_HTTP_METHODS environment variable in the Retry Policy section of README.md.  Absence of backslash meant that they were not rendered in the text.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
