### PR TITLE
Test fix sslexception bad record mac at def import dp

### DIFF
--- a/.github/workflows/ado_artifacts_build.yml
+++ b/.github/workflows/ado_artifacts_build.yml
@@ -2,6 +2,11 @@ name: Publish to Azure Artifacts
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Artifact version to publish when running manually'
+        required: true
+        type: string
   push:
     tags:
       - '*'
@@ -23,11 +28,22 @@ jobs:
           java-version: 21
           cache: 'gradle'
 
+      - name: Validate manual release version
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          release_version="${{ inputs.release_version }}"
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([_-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "Invalid release_version: $release_version"
+            echo "Expected examples: 9.2.2_BEFTA-1234 or 9.2.2-rc1"
+            exit 1
+          fi
+        shell: bash
+
       - name: Publish to Azure DevOps Artifacts
         run: |
           ./gradlew publish
         env:
           AZURE_DEVOPS_ARTIFACT_USERNAME: ${{ secrets.AZURE_DEVOPS_ARTIFACT_USERNAME }}
           AZURE_DEVOPS_ARTIFACT_TOKEN: ${{ secrets.AZURE_DEVOPS_ARTIFACT_TOKEN }}
-          RELEASE_VERSION: ${{ github.ref_name }}
+          RELEASE_VERSION: ${{ inputs.release_version || github.ref_name }}
         shell: bash

--- a/.github/workflows/ado_artifacts_build.yml
+++ b/.github/workflows/ado_artifacts_build.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Validate release version
         run: |
           release_version="${{ env.release_version }}"
-          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(_BEFTA-[0-9]+|-rc[0-9]+)?$ ]]; then
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(_(BEFTA|CCD)-[0-9]+|-rc[0-9]+)?$ ]]; then
             echo "Invalid release_version: $release_version"
-            echo "Expected formats: 9.2.2, 9.2.2_BEFTA-1234, or 9.2.2-rc1"
+            echo "Expected formats: 9.2.2, 9.2.2_BEFTA-1234, 9.2.2_CCD-7522, or 9.2.2-rc1"
             exit 1
           fi
         shell: bash

--- a/.github/workflows/ado_artifacts_build.yml
+++ b/.github/workflows/ado_artifacts_build.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Resolve release version
+        run: |
+          release_version="${{ inputs.release_version || github.ref_name }}"
+          echo "release_version=$release_version" >> "$GITHUB_ENV"
+        shell: bash
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -28,15 +34,35 @@ jobs:
           java-version: 21
           cache: 'gradle'
 
-      - name: Validate manual release version
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Validate release version
         run: |
-          release_version="${{ inputs.release_version }}"
-          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([_-][A-Za-z0-9.-]+)?$ ]]; then
+          release_version="${{ env.release_version }}"
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(_BEFTA-[0-9]+|-rc[0-9]+)?$ ]]; then
             echo "Invalid release_version: $release_version"
-            echo "Expected examples: 9.2.2_BEFTA-1234 or 9.2.2-rc1"
+            echo "Expected formats: 9.2.2, 9.2.2_BEFTA-1234, or 9.2.2-rc1"
             exit 1
           fi
+        shell: bash
+
+      - name: Fail if artifact version already exists
+        run: |
+          metadata_url="https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1/com/github/hmcts/befta-fw/maven-metadata.xml"
+          metadata_file="$(mktemp)"
+
+          curl --fail --silent --show-error \
+            --user "${AZURE_DEVOPS_ARTIFACT_USERNAME}:${AZURE_DEVOPS_ARTIFACT_TOKEN}" \
+            --output "$metadata_file" \
+            "$metadata_url"
+
+          if grep -Fqx "      <version>${{ env.release_version }}</version>" "$metadata_file" || \
+             grep -Fqx "    <release>${{ env.release_version }}</release>" "$metadata_file" || \
+             grep -Fqx "    <latest>${{ env.release_version }}</latest>" "$metadata_file"; then
+            echo "Artifact version already exists: ${{ env.release_version }}"
+            exit 1
+          fi
+        env:
+          AZURE_DEVOPS_ARTIFACT_USERNAME: ${{ secrets.AZURE_DEVOPS_ARTIFACT_USERNAME }}
+          AZURE_DEVOPS_ARTIFACT_TOKEN: ${{ secrets.AZURE_DEVOPS_ARTIFACT_TOKEN }}
         shell: bash
 
       - name: Publish to Azure DevOps Artifacts
@@ -45,5 +71,5 @@ jobs:
         env:
           AZURE_DEVOPS_ARTIFACT_USERNAME: ${{ secrets.AZURE_DEVOPS_ARTIFACT_USERNAME }}
           AZURE_DEVOPS_ARTIFACT_TOKEN: ${{ secrets.AZURE_DEVOPS_ARTIFACT_TOKEN }}
-          RELEASE_VERSION: ${{ inputs.release_version || github.ref_name }}
+          RELEASE_VERSION: ${{ env.release_version }}
         shell: bash

--- a/.github/workflows/delete_ado_artifacts_versions.yml
+++ b/.github/workflows/delete_ado_artifacts_versions.yml
@@ -1,0 +1,105 @@
+name: Delete Azure Artifacts Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Newline-separated artifact versions to delete'
+        required: true
+        type: string
+      delete_mode:
+        description: 'Delete mode'
+        required: true
+        default: recycle_bin
+        type: choice
+        options:
+          - recycle_bin
+          - permanent_delete
+      dry_run:
+        description: 'Preview only without deleting'
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  DeleteAzureArtifactsVersions:
+    runs-on: ubuntu-latest
+    environment: artifact-cleanup
+
+    steps:
+      - name: Check actor is allowlisted
+        env:
+          GITHUB_ACTOR_NAME: ${{ github.actor }}
+          ALLOWED_USERS: ${{ vars.ARTIFACT_DELETE_ALLOWED_USERS }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${ALLOWED_USERS// }" ]]; then
+            echo "Repository variable ARTIFACT_DELETE_ALLOWED_USERS is not configured."
+            exit 1
+          fi
+
+          allowed_match=false
+          IFS=',' read -ra allowed_users <<< "$ALLOWED_USERS"
+          for allowed_user in "${allowed_users[@]}"; do
+            allowed_user="${allowed_user#"${allowed_user%%[![:space:]]*}"}"
+            allowed_user="${allowed_user%"${allowed_user##*[![:space:]]}"}"
+            if [[ "$GITHUB_ACTOR_NAME" == "$allowed_user" ]]; then
+              allowed_match=true
+              break
+            fi
+          done
+
+          if [[ "$allowed_match" != "true" ]]; then
+            echo "User ${GITHUB_ACTOR_NAME} is not permitted to run this workflow."
+            exit 1
+          fi
+        shell: bash
+
+      - name: Delete requested artifact versions
+        env:
+          AZURE_DEVOPS_ARTIFACT_USERNAME: ${{ secrets.AZURE_DEVOPS_ARTIFACT_USERNAME }}
+          AZURE_DEVOPS_ARTIFACT_TOKEN: ${{ secrets.AZURE_DEVOPS_ARTIFACT_TOKEN }}
+          RAW_VERSIONS: ${{ inputs.versions }}
+          DELETE_MODE: ${{ inputs.delete_mode }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          ORGANIZATION: hmcts
+          FEED: hmcts-lib
+          GROUP_ID: com.github.hmcts
+          ARTIFACT_ID: befta-fw
+        run: |
+          set -euo pipefail
+
+          group_path="${GROUP_ID//./\/}"
+
+          if [[ "$DELETE_MODE" == "recycle_bin" ]]; then
+            base_url="https://pkgs.dev.azure.com/${ORGANIZATION}/Artifacts/_packaging/${FEED}/maven/groups/${group_path}/artifacts/${ARTIFACT_ID}/versions"
+          else
+            base_url="https://pkgs.dev.azure.com/${ORGANIZATION}/Artifacts/_packaging/${FEED}/maven/RecycleBin/groups/${group_path}/artifacts/${ARTIFACT_ID}/versions"
+          fi
+
+          while IFS= read -r version; do
+            version="${version#"${version%%[![:space:]]*}"}"
+            version="${version%"${version##*[![:space:]]}"}"
+
+            if [[ -z "$version" ]]; then
+              continue
+            fi
+
+            encoded_version="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$version")"
+            delete_url="${base_url}/${encoded_version}?api-version=7.1-preview.1"
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "DRY RUN: would delete ${GROUP_ID}:${ARTIFACT_ID}:${version} using ${DELETE_MODE}"
+              echo "DRY RUN: ${delete_url}"
+              continue
+            fi
+
+            echo "Deleting ${GROUP_ID}:${ARTIFACT_ID}:${version} using ${DELETE_MODE}"
+            curl --fail --silent --show-error \
+              --request DELETE \
+              --user "${AZURE_DEVOPS_ARTIFACT_USERNAME}:${AZURE_DEVOPS_ARTIFACT_TOKEN}" \
+              "$delete_url"
+            echo "Deleted ${version}"
+          done <<< "$RAW_VERSIONS"
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -5,6 +5,71 @@
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
+## Publishing a Release
+
+This repository publishes release artifacts to Azure Artifacts using the GitHub Actions workflow
+`Publish to Azure Artifacts`.
+
+There are two supported ways to publish:
+
+1. Manual run from GitHub Actions using a `release_version` value.
+2. Push a Git tag and use the tag name as the release version.
+
+### Manual publish
+
+Use this when you want to publish a pre-release or a version that should not be derived from the branch name.
+
+In GitHub:
+
+1. Open `Actions`.
+2. Open the `Publish to Azure Artifacts` workflow.
+3. Select `Run workflow`.
+4. Enter a `release_version`.
+5. Run the workflow.
+
+Examples of valid manual `release_version` values:
+
+* `9.2.2`
+* `9.2.2_BEFTA-1234`
+* `9.2.2-rc1`
+
+Examples of invalid values:
+
+* `feature/my-branch`
+* `BEFTA-1234`
+* `release 9.2.2`
+
+If the value is invalid, the workflow fails early with an error before publishing anything.
+
+### Tag-based publish
+
+If the workflow is triggered by pushing a Git tag, the tag name is used as the artifact version.
+
+For example:
+
+```bash
+git tag 9.2.2
+git push origin 9.2.2
+```
+
+Examples:
+
+* Tag `9.2.2` publishes version `9.2.2`
+* Tag `9.2.2-rc1` publishes version `9.2.2-rc1`
+* Tag `9.2.2_BEFTA-1234` publishes version `9.2.2_BEFTA-1234`
+
+### Which option to use
+
+Use manual publish when:
+
+* you are testing a pre-release version
+* you want an explicit version that is independent of the branch name
+
+Use tag-based publish when:
+
+* you want the Git tag to be the release version
+* you are performing a normal tagged release
+
 
 ## 1) WHAT IS BEFTA FRAMEWORK?
 BEFTA Framework is a framework for automation of functional tests for http-based APIs. It uses Cucumber and Rest Assured frameworks and supports a BDD (Behaviour-Driven Development) approach to software development.
@@ -855,4 +920,3 @@ In this example, the framework will wait for 10 seconds before making the reques
 it is submitted to call the [Get User Details] operation of [User Management Service] with a delay of [5] seconds [after] the call
 ```
 Here, the framework will wait for 5 seconds after making the request to "Get User Details" operation of the "User Management Service" before proceeding with the next steps.
-

--- a/README.md
+++ b/README.md
@@ -12,12 +12,38 @@ This repository publishes release artifacts to Azure Artifacts using the GitHub 
 
 There are two supported ways to publish:
 
-1. Manual run from GitHub Actions using a `release_version` value.
-2. Push a Git tag and use the tag name as the release version.
+| Method | When to use | Version source | Naming rule |
+| --- | --- | --- |
+| Manual publish | Pre-release or explicit version publish | `release_version` entered in GitHub Actions | Must match the valid version format below |
+| Tag-based publish | Normal tagged release | Git tag name | Tag name must match the valid version format below |
+
+### Version format
+
+The same version format is used for manual `release_version` values and tag-based releases.
+
+Naming rule:
+
+| Case | Format | Example |
+| --- | --- | --- |
+| Released version | `<major>.<minor>.<patch>` | `9.2.2` |
+| PR or pre-release version | `<major>.<minor>.<patch>_BEFTA-<ticket>` | `9.2.2_BEFTA-1234` |
+| Release candidate version | `<major>.<minor>.<patch>-<suffix>` | `9.2.2-rc1` |
+
+Examples of valid values:
+
+| Valid | Invalid |
+| --- | --- |
+| `9.2.2` | `feature/my-branch` |
+| `9.2.2_BEFTA-1234` | `BEFTA-1234` |
+| `9.2.2-rc1` | `release 9.2.2` |
+|  | `9.2.2_hotfix` |
+|  | `9.2.2-feature1` |
+|  | `9.2.2_BEFTA1234` |
+
+If the value is invalid, the workflow fails early with an error before publishing anything.
+If the artifact version already exists in Azure Artifacts, the workflow also fails before publishing.
 
 ### Manual publish
-
-Use this when you want to publish a pre-release or a version that should not be derived from the branch name.
 
 In GitHub:
 
@@ -26,20 +52,6 @@ In GitHub:
 3. Select `Run workflow`.
 4. Enter a `release_version`.
 5. Run the workflow.
-
-Examples of valid manual `release_version` values:
-
-* `9.2.2`
-* `9.2.2_BEFTA-1234`
-* `9.2.2-rc1`
-
-Examples of invalid values:
-
-* `feature/my-branch`
-* `BEFTA-1234`
-* `release 9.2.2`
-
-If the value is invalid, the workflow fails early with an error before publishing anything.
 
 ### Tag-based publish
 
@@ -52,23 +64,32 @@ git tag 9.2.2
 git push origin 9.2.2
 ```
 
-Examples:
-
-* Tag `9.2.2` publishes version `9.2.2`
-* Tag `9.2.2-rc1` publishes version `9.2.2-rc1`
-* Tag `9.2.2_BEFTA-1234` publishes version `9.2.2_BEFTA-1234`
-
 ### Which option to use
 
-Use manual publish when:
+| Use manual publish when | Use tag-based publish when |
+| --- | --- |
+| you are testing a pre-release version | you want the Git tag to be the release version |
+| you want an explicit version that is independent of the branch name | you are performing a normal tagged release |
 
-* you are testing a pre-release version
-* you want an explicit version that is independent of the branch name
+### Artifact cleanup workflow setup
 
-Use tag-based publish when:
+The `Delete Azure Artifacts Versions` workflow is intended for repository maintainers only.
 
-* you want the Git tag to be the release version
-* you are performing a normal tagged release
+| Requirement | Purpose |
+| --- | --- |
+| GitHub Actions environment `artifact-cleanup` | Adds an approval gate for deletion |
+| Required reviewers on `artifact-cleanup` | Restricts who can approve cleanup runs |
+| Repository variable `ARTIFACT_DELETE_ALLOWED_USERS` | Restricts who can start the workflow |
+| Secrets `AZURE_DEVOPS_ARTIFACT_USERNAME` and `AZURE_DEVOPS_ARTIFACT_TOKEN` | Authorises Azure Artifacts API calls |
+
+Recommended usage:
+
+| Setting | Recommendation |
+| --- | --- |
+| `dry_run` | Run with `true` first |
+| `delete_mode` | Use `recycle_bin` before `permanent_delete` |
+
+Deleting a version from Azure Artifacts does not make that version reusable.
 
 
 ## 1) WHAT IS BEFTA FRAMEWORK?

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Naming rule:
 | Case | Format | Example |
 | --- | --- | --- |
 | Released version | `<major>.<minor>.<patch>` | `9.2.2` |
-| PR or pre-release version | `<major>.<minor>.<patch>_BEFTA-<ticket>` | `9.2.2_BEFTA-1234` |
+| PR or pre-release version | `<major>.<minor>.<patch>_<ticket-prefix>-<ticket>` | `9.2.2_BEFTA-1234`, `9.2.2_CCD-7522` |
 | Release candidate version | `<major>.<minor>.<patch>-<suffix>` | `9.2.2-rc1` |
+
+Supported ticket prefixes are `BEFTA` and `CCD`.
 
 Examples of valid values:
 
@@ -35,6 +37,7 @@ Examples of valid values:
 | --- | --- |
 | `9.2.2` | `feature/my-branch` |
 | `9.2.2_BEFTA-1234` | `BEFTA-1234` |
+| `9.2.2_CCD-7522` | `9.2.2_CCD7522` |
 | `9.2.2-rc1` | `release 9.2.2` |
 |  | `9.2.2_hotfix` |
 |  | `9.2.2-feature1` |

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "7.26.6-SSL-FIX"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "7.26.6_CCD-7522"
 System.out.println("version = " + buildNumber)
 
 group 'com.github.hmcts'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "7.26.6_CCD-7522"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "9.2.6_CCD-7522"
 System.out.println("version = " + buildNumber)
 
 group 'com.github.hmcts'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION") ?: "9.2.3-SNAPSHOT"
+def buildNumber = System.getenv("RELEASE_VERSION") ?: "7.26.6-SSL-FIX"
 System.printf("version: " + buildNumber)
 
 group 'com.github.hmcts'

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION") ?: "9.2.2"
-System.printf("version: " + buildNumber)
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "9.2.5"
+System.out.println("version = " + buildNumber)
 
 group 'com.github.hmcts'
 

--- a/src/main/java/uk/gov/hmcts/befta/dse/ccd/DataLoaderToDefinitionStore.java
+++ b/src/main/java/uk/gov/hmcts/befta/dse/ccd/DataLoaderToDefinitionStore.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.befta.dse.ccd;
 
+import com.github.rholder.retry.Retryer;
 import com.google.common.reflect.ClassPath;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -24,6 +25,7 @@ import uk.gov.hmcts.befta.util.BeftaUtils;
 import uk.gov.hmcts.befta.util.EnvironmentVariableUtils;
 import uk.gov.hmcts.befta.util.FileUtils;
 import uk.gov.hmcts.befta.util.JsonUtils;
+import uk.gov.hmcts.befta.util.Retryable;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -45,6 +47,9 @@ import java.util.stream.Collectors;
 
 import io.restassured.http.Header;
 
+import static uk.gov.hmcts.befta.util.HttpRequestRetryer.createRetryer;
+import static uk.gov.hmcts.befta.util.HttpRequestRetryer.executeHttpRequestWithRetry;
+
 public class DataLoaderToDefinitionStore extends DefaultBeftaTestDataLoader {
 
     private static final Logger logger = LoggerFactory.getLogger(DataLoaderToDefinitionStore.class);
@@ -52,6 +57,8 @@ public class DataLoaderToDefinitionStore extends DefaultBeftaTestDataLoader {
     public static final String VALID_CCD_TEST_DEFINITIONS_PATH = "uk/gov/hmcts/ccd/test_definitions/valid";
 
     private static final String TEMPORARY_DEFINITION_FOLDER = "definition_files";
+    private static final String IMPORT_DEFINITION_PATH = "/import";
+    private static final String POST_METHOD = "POST";
 
     private static final String[] RA_DATA_RESOURCE_PACKAGES = { "roleAssignments" };
 
@@ -95,6 +102,7 @@ public class DataLoaderToDefinitionStore extends DefaultBeftaTestDataLoader {
     private final TestAutomationAdapter adapter;
     private final String definitionStoreUrl;
     private final String definitionsPath;
+    private final Retryer<Response> definitionImportRetryer;
 
     public DataLoaderToDefinitionStore(String definitionsPath) {
         this(new DefaultTestAutomationAdapter(), definitionsPath, CcdEnvironment.AAT,
@@ -131,6 +139,7 @@ public class DataLoaderToDefinitionStore extends DefaultBeftaTestDataLoader {
         this.adapter = adapter;
         this.definitionsPath = definitionsPath;
         this.definitionStoreUrl = definitionStoreUrl;
+        this.definitionImportRetryer = createRetryer(Retryable.RETRYABLE_FROM_CONFIG, POST_METHOD);
     }
 
     private static CcdEnvironment selectEnvironmentWith(CcdEnvironment dataSetupEnvironment,
@@ -413,7 +422,12 @@ public class DataLoaderToDefinitionStore extends DefaultBeftaTestDataLoader {
         File file = new File(fileResourcePath).exists() ? new File(fileResourcePath)
                 : BeftaUtils.getClassPathResourceIntoTemporaryFile(fileResourcePath);
         try {
-            Response response = asAutoTestImporter().given().multiPart(file).when().post("/import");
+            RequestSpecification importRequest = asAutoTestImporter().given().multiPart(file).when();
+            Response response = executeHttpRequestWithRetry(
+                    importRequest,
+                    POST_METHOD,
+                    IMPORT_DEFINITION_PATH,
+                    getDefinitionImportRetryer());
             if (response.getStatusCode() != 201) {
                 String message = "Import failed with response body: " + response.body().prettyPrint();
                 message += "\nand http code: " + response.statusCode();
@@ -422,6 +436,10 @@ public class DataLoaderToDefinitionStore extends DefaultBeftaTestDataLoader {
         } finally {
             file.delete();
         }
+    }
+
+    protected Retryer<Response> getDefinitionImportRetryer() {
+        return definitionImportRetryer;
     }
 
     protected RequestSpecification asAutoTestImporter() {

--- a/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
+++ b/src/main/java/uk/gov/hmcts/befta/player/DefaultBackEndFunctionalTestScenarioPlayer.java
@@ -65,6 +65,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static uk.gov.hmcts.befta.util.HttpRequestRetryer.createRetryer;
+import static uk.gov.hmcts.befta.util.HttpRequestRetryer.executeHttpRequestWithRetry;
+
 public class DefaultBackEndFunctionalTestScenarioPlayer implements BackEndFunctionalTestAutomationDSL {
 
     static final String HTTP_S_REGEX = "^(http|https):.*";
@@ -402,40 +405,9 @@ public class DefaultBackEndFunctionalTestScenarioPlayer implements BackEndFuncti
         }
 
         Retryable retryable = scenarioContext.getRetryConfiguration();
-        Retryer<Response> retryer;
+        Retryer<Response> retryer = createRetryer(retryable, testData.getMethod());
 
         logger.info("Calling: {} {}", testData.getMethod(), uri);
-        if (retryable.getNonRetryableHttpMethods().contains("*") || retryable.getNonRetryableHttpMethods()
-                                                                                .contains(testData.getMethod())) {
-            logger.info("Applying no-retry policy...");
-            retryer = RetryerBuilder.<Response>newBuilder().build();
-        } else {
-            retryer = RetryerBuilder.<Response>newBuilder()
-                    .withRetryListener(retryable.getRetryListener())
-                    .retryIfException(e -> {
-                        boolean isRetryableException = retryable.getRetryableExceptions().contains(e.getClass());
-                        Throwable cause = e.getCause();
-                        boolean isRetryableCause = cause != null && retryable.getRetryableExceptions()
-                                .contains(cause.getClass());
-                        return isRetryableException || isRetryableCause;
-                    })
-                    .retryIfResult(res -> retryable.getStatusCodes().contains(res.getStatusCode()))
-                    .retryIfResult(res -> {
-                        for (String match : retryable.getMatch()) {
-                            Pattern pattern = Pattern.compile(match);
-                            Matcher matcher = pattern.matcher(res.asString());
-                            if (matcher.find()) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    })
-                    .withStopStrategy(StopStrategies.stopAfterAttempt(retryable.getMaxAttempts()))
-                    .withWaitStrategy(WaitStrategies.fixedWait(retryable.getDelay(), TimeUnit.MILLISECONDS))
-                    .build();
-
-            logger.info("Applying active retry policy... {}", retryable);
-        }
 
         Response response = executeHttpRequestWithRetry(theRequest, testData.getMethod(), uri, retryer);
         ResponseData responseData = convertRestAssuredResponseToBeftaResponse(scenarioContext, response);
@@ -444,21 +416,6 @@ public class DefaultBackEndFunctionalTestScenarioPlayer implements BackEndFuncti
         scenario.log("Called: " + queryableRequest.getMethod() + " " + queryableRequest.getURI());
         scenario.log("Response:\n" + JsonUtils.getPrettyJsonFromObject(scenarioContext.getTheResponse()));
         scenarioContext.injectDataFromContextAfterApiCall();
-    }
-
-    private Response executeHttpRequestWithRetry(RequestSpecification theRequest, String method, String uri,
-                                                        Retryer<Response> retryer) {
-        try {
-            Callable<Response> callable = () -> theRequest.request(method, uri);
-            return retryer.call(callable);
-        } catch (RetryException retryException) {
-            throw new FunctionalTestException(
-                    String.format("Retry Exception when calling %s", uri), retryException);
-        } catch (ExecutionException executionException) {
-            throw new FunctionalTestException(
-                    String.format("Execution Exception when authenticating user %s", uri),
-                    executionException);
-        }
     }
 
     private ResponseData convertRestAssuredResponseToBeftaResponse(BackEndFunctionalTestScenarioContext scenarioContext,

--- a/src/main/java/uk/gov/hmcts/befta/util/HttpRequestRetryer.java
+++ b/src/main/java/uk/gov/hmcts/befta/util/HttpRequestRetryer.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.befta.util;
+
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.befta.exception.FunctionalTestException;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class HttpRequestRetryer {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequestRetryer.class);
+    private static final String ALL_HTTP_METHODS = "*";
+
+    private HttpRequestRetryer() {
+    }
+
+    public static Retryer<Response> createRetryer(Retryable retryable, String method) {
+        if (retryable.getNonRetryableHttpMethods().contains(ALL_HTTP_METHODS)
+                || retryable.getNonRetryableHttpMethods().contains(method)) {
+            logger.info("Applying no-retry policy...");
+            return RetryerBuilder.<Response>newBuilder().build();
+        }
+
+        logger.info("Applying active retry policy... {}", retryable);
+        return RetryerBuilder.<Response>newBuilder()
+                .withRetryListener(retryable.getRetryListener())
+                .retryIfException(e -> {
+                    boolean isRetryableException = retryable.getRetryableExceptions().contains(e.getClass());
+                    Throwable cause = e.getCause();
+                    boolean isRetryableCause = cause != null && retryable.getRetryableExceptions()
+                            .contains(cause.getClass());
+                    return isRetryableException || isRetryableCause;
+                })
+                .retryIfResult(res -> retryable.getStatusCodes().contains(res.getStatusCode()))
+                .retryIfResult(res -> {
+                    for (String match : retryable.getMatch()) {
+                        Pattern pattern = Pattern.compile(match);
+                        Matcher matcher = pattern.matcher(res.asString());
+                        if (matcher.find()) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .withStopStrategy(StopStrategies.stopAfterAttempt(retryable.getMaxAttempts()))
+                .withWaitStrategy(WaitStrategies.fixedWait(retryable.getDelay(), TimeUnit.MILLISECONDS))
+                .build();
+    }
+
+    public static Response executeHttpRequestWithRetry(RequestSpecification theRequest, String method, String uri,
+                                                       Retryer<Response> retryer) {
+        try {
+            Callable<Response> callable = () -> theRequest.request(method, uri);
+            return retryer.call(callable);
+        } catch (RetryException retryException) {
+            throw new FunctionalTestException(
+                    String.format("Retry Exception when calling %s", uri), retryException);
+        } catch (ExecutionException executionException) {
+            throw new FunctionalTestException(
+                    String.format("Execution Exception when calling %s", uri), executionException);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/befta/dse/ccd/TestDataLoaderToDefinitionStore.java
+++ b/src/test/java/uk/gov/hmcts/befta/dse/ccd/TestDataLoaderToDefinitionStore.java
@@ -2,16 +2,20 @@ package uk.gov.hmcts.befta.dse.ccd;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
+import com.github.rholder.retry.Retryer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.MockedStatic;
 
@@ -21,16 +25,25 @@ import io.restassured.response.ResponseBody;
 import io.restassured.specification.RequestSpecification;
 import uk.gov.hmcts.befta.DefaultTestAutomationAdapter;
 import uk.gov.hmcts.befta.TestAutomationAdapter;
+import uk.gov.hmcts.befta.util.Retryable;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
+import javax.net.ssl.SSLException;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.befta.util.HttpRequestRetryer.createRetryer;
 
 @SuppressWarnings({"LineLength","VariableDeclarationUsageDistance"})
 class TestDataLoaderToDefinitionStore {
@@ -259,6 +272,55 @@ class TestDataLoaderToDefinitionStore {
         fail("Not yet implemented");
     }
 
+    @Test
+    @SetEnvironmentVariable(key = DEFINITION_STORE_HOST_KEY, value = DEFINITION_STORE_HOST_VALUE)
+    @SetEnvironmentVariable(key = IDAM_URL_KEY, value = IDAM_URL_VALUE)
+    @SetEnvironmentVariable(key = BEFTA_S2S_CLIENT_ID_KEY, value = BEFTA_S2S_CLIENT_ID_VALUE)
+    @SetEnvironmentVariable(key = BEFTA_S2S_CLIENT_SECRET_KEY, value = BEFTA_S2S_CLIENT_SECRET_VALUE)
+    @SetEnvironmentVariable(key = S2S_URL_KEY, value = S2S_URL_VALUE)
+    @SetEnvironmentVariable(key = CCD_IMPORT_AUTOTEST_EMAIL, value = CCD_IMPORT_AUTOTEST_EMAIL_VALUE)
+    @SetEnvironmentVariable(key = CCD_IMPORT_AUTOTEST_PASSWORD, value = CCD_IMPORT_AUTOTEST_PASSWORD_VALUE)
+    @SetEnvironmentVariable(key = "CCD_API_GATEWAY_OAUTH2_CLIENT_ID", value = "OAUTH2_CLIENT_ID_VALUE")
+    @SetEnvironmentVariable(key = "CCD_API_GATEWAY_OAUTH2_CLIENT_SECRET", value = "OAUTH2_CLIENT_SECRET_VALUE")
+    @SetEnvironmentVariable(key = "CCD_API_GATEWAY_OAUTH2_REDIRECT_URL", value = "OAUTH2_REDIRECT_URI_VALUE")
+    void testImportDefinitionRetriesRetryableSslException(@TempDir Path tempDir) throws IOException {
+        TestAutomationAdapter mockAdapter = mock(TestAutomationAdapter.class);
+        when(mockAdapter.getNewS2STokenWithEnvVars("CCD_API_GATEWAY_S2S_ID", "CCD_API_GATEWAY_S2S_KEY"))
+                .thenReturn("s2s_token");
+
+        RequestSpecification requestSpecification = mock(RequestSpecification.class);
+        Response rs = mock(Response.class);
+
+        when(RestAssured.given(any())).thenReturn(requestSpecification);
+        when(requestSpecification.header(any())).thenReturn(requestSpecification);
+        when(requestSpecification.given()).thenReturn(requestSpecification);
+        when(requestSpecification.multiPart(any(File.class))).thenReturn(requestSpecification);
+        when(requestSpecification.when()).thenReturn(requestSpecification);
+        when(requestSpecification.request(eq("POST"), eq("/import")))
+                .thenAnswer(invocation -> {
+                    throw new SSLException("bad_record_mac");
+                })
+                .thenReturn(rs);
+        when(rs.getStatusCode()).thenReturn(201);
+
+        Retryable retryable = Retryable.builder()
+                .maxAttempts(2)
+                .retryableExceptions(Set.of(SSLException.class))
+                .nonRetryableHttpMethods(Set.of())
+                .retryListener(Retryable.setRetryListener(false))
+                .build();
+        DataLoaderToDefinitionStore dataLoaderToDefinitionStore = new RetryableDataLoaderToDefinitionStore(
+                mockAdapter,
+                createRetryer(retryable, "POST"));
+
+        Path definitionFile = Files.writeString(tempDir.resolve("definition.xlsx"), "definition");
+
+        dataLoaderToDefinitionStore.importDefinition(definitionFile.toString());
+
+        verify(requestSpecification, times(2)).request(eq("POST"), eq("/import"));
+        verify(requestSpecification, never()).post("/import");
+    }
+
     @Disabled("Not yet implemented")
     @Test
     void testAsAutoTestImporter() {
@@ -357,6 +419,21 @@ class TestDataLoaderToDefinitionStore {
                 Arguments.of("ccd-roles-test-data/without-ccd-roles/definitions", numberOfCcdRolesInDefaultList),
                 Arguments.of("ccd-roles-test-data/with-bad-ccd-roles/definitions", numberOfCcdRolesInDefaultList)
         );
+    }
+
+    private static class RetryableDataLoaderToDefinitionStore extends DataLoaderToDefinitionStore {
+
+        private final Retryer<Response> definitionImportRetryer;
+
+        RetryableDataLoaderToDefinitionStore(TestAutomationAdapter adapter, Retryer<Response> definitionImportRetryer) {
+            super(adapter);
+            this.definitionImportRetryer = definitionImportRetryer;
+        }
+
+        @Override
+        protected Retryer<Response> getDefinitionImportRetryer() {
+            return definitionImportRetryer;
+        }
     }
 
 }


### PR DESCRIPTION
### Jira link

NA

### Change description

Extracted the existing RestAssured retry flow into HttpRequestRetryer.java (line 28), updated the scenario player to use it, and changed DataLoaderToDefinitionStore.java (line 421) so definition imports now call executeHttpRequestWithRetry via request("POST", "/import") with the configured import retryer.

Added a focused test in TestDataLoaderToDefinitionStore.java (line 286) that simulates SSLException("bad_record_mac"), verifies the retry, and verifies the old direct .post("/import") path is not used.

### Testing done

To be tested in definition store with this specific befta-fw library version to assess whether SSL exception is fixed.

### Security Vulnerability Assessment ###

NA

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
