### PR TITLE
Upgrade REST Assured to 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ wrapper.gradleVersion = '8.10'
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.17.1'
 
-    implementation group: 'io.rest-assured', name: 'rest-assured', version: '5.4.0'
+    implementation group: 'io.rest-assured', name: 'rest-assured', version: '6.0.1'
 
     api group: 'io.cucumber', name: 'cucumber-java', version: '7.18.0'
     api group: 'io.cucumber', name: 'cucumber-junit', version: '7.18.0'


### PR DESCRIPTION
## Summary
- Upgrade REST Assured from 5.4.0 to 6.0.1.
- Provide Groovy 5 compatibility for Spring Boot 4 consumers.

## Verification
- BEFTA clean test suite passed.
- Published locally as version 9.2.8-SNAPSHOT.
- Confirmed a Spring Boot 4 service resolves REST Assured 6.0.1.
- Reproduced the consumer smoke path and confirmed it reaches the HTTP client without the previous Groovy reflection NPE.